### PR TITLE
Add break in switch sentence

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -871,6 +871,7 @@ pointer ROSEUS_CONSOLE_BRIDGE_SET_LOG_LEVEL(register context *ctx,int n,pointer 
     break;
   case 3:
     level = console_bridge::CONSOLE_BRIDGE_LOG_ERROR;
+    break;
   default:
     return (NIL);
   }

--- a/roseus/test/test-console-bridge.l
+++ b/roseus/test/test-console-bridge.l
@@ -1,0 +1,24 @@
+#!/usr/bin/env roseus
+
+(require :unittest "lib/llib/unittest.l")
+(setq sys::*gc-hook* #'(lambda (a b) (format *error-output* ";; gc ~A ~A~%" a b)))
+(init-unit-test)
+
+;;
+(deftest test-console-bridge
+    (dolist (level (list ros::*console-bridge-log-debug*
+                         ros::*console-bridge-log-info*
+                         ros::*console-bridge-log-warn*
+                         ros::*console-bridge-log-error*))
+      (warning-message 2 "check ~A level~%" level)
+      (ros::console-bridge-set-log-level level)
+      (warning-message 2 "  current log level ~A~%" (ros::console-bridge-get-log-level))
+      (ros::console-bridge-log-error "this is ERROR message")
+      (ros::console-bridge-log-warn "this is WARN message")
+      (ros::console-bridge-log-info "this is INFO message")
+      (ros::console-bridge-log-debug "this is DEBUG message")
+      ))
+
+(run-all-tests)
+
+(exit)

--- a/roseus/test/test-console-bridge.test
+++ b/roseus/test/test-console-bridge.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="test_console_bridge" pkg="roseus" type="test-console-bridge.l" name="test_console_bridge" />
+</launch>


### PR DESCRIPTION
Without this PR, we couldn't set `ros::console-bridge-set-log-level 3` . When we do this, the function returns `NIL`